### PR TITLE
Use sync/atomic.Value to store certificate and avoid sync.RWMutex.

### DIFF
--- a/certinel_go1.8.go
+++ b/certinel_go1.8.go
@@ -10,8 +10,6 @@ import (
 // can be passed as the GetClientCertificate member in a tls.Config object. It is
 // safe to call across multiple goroutines.
 func (c *Certinel) GetClientCertificate(certificateRequest *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.certificate, nil
+	cert, _ := c.certificate.Load().(*tls.Certificate)
+	return cert, nil
 }


### PR DESCRIPTION
This pull request switches the previous [sync.RWMutex](https://golang.org/pkg/sync/#RWMutex) system for one based on [sync/atomic.Value](https://golang.org/pkg/sync/atomic/#Value). This provides a significant speedup while also avoiding sync.RWMutex's scaling problems, see golang/go#17973.

```
name                      old time/op  new time/op  delta
GetCertificate-8          54.1ns ± 1%   4.9ns ± 2%  -90.91%  (p=0.000 n=9+10)
GetCertificateParallel-8  53.1ns ± 1%   1.7ns ± 3%  -96.85%  (p=0.000 n=10+9)
```

This pull request also adds two benchmarks (GetCertificate & GetCertificateParallel) to measure the performance of this approach. It makes no other changes.