### PR TITLE
Avoid channel race conditions and exit goroutines

### DIFF
--- a/certinel.go
+++ b/certinel.go
@@ -42,12 +42,20 @@ func (c *Certinel) Watch() {
 	go func() {
 		tlsChan, errChan := c.watcher.Watch()
 
-		for {
+		for tlsChan != nil && errChan != nil {
 			select {
-			case certificate := <-tlsChan:
-				c.certificate.Store(&certificate)
-			case err := <-errChan:
-				c.errBack(err)
+			case certificate, ok := <-tlsChan:
+				if ok {
+					c.certificate.Store(&certificate)
+				} else {
+					tlsChan = nil
+				}
+			case err, ok := <-errChan:
+				if ok {
+					c.errBack(err)
+				} else {
+					errChan = nil
+				}
 			}
 		}
 	}()

--- a/fswatcher/fswatcher_test.go
+++ b/fswatcher/fswatcher_test.go
@@ -54,11 +54,6 @@ func TestClose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; runtime.NumGoroutine() != goCount && i < 10; i++ {
-		runtime.Gosched()
-		time.Sleep(10 * time.Millisecond)
-	}
-
 	if n := runtime.NumGoroutine(); n != goCount {
 		t.Fatalf("expected %v goroutines, found %v", goCount, n)
 	}
@@ -71,5 +66,10 @@ func TestClose(t *testing.T) {
 		if ok {
 			t.Errorf("receive on channel expected to be closed")
 		}
+	}
+
+	// Subsequent calls to Close return nil and do not panic.
+	if err := watcher.Close(); err != nil {
+		t.Error(err)
 	}
 }

--- a/fswatcher/fswatcher_test.go
+++ b/fswatcher/fswatcher_test.go
@@ -1,0 +1,75 @@
+package fswatcher_test
+
+import (
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/certinel/fswatcher"
+)
+
+func TestClose(t *testing.T) {
+	// Prepare (empty, invalid) cert and key files to watch.
+	certFile, err := ioutil.TempFile("", "cert")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(certFile.Name())
+
+	keyFile, err := ioutil.TempFile("", "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(keyFile.Name())
+
+	// Record the number of goroutines before starting the watch.
+	goCount := runtime.NumGoroutine()
+
+	// Start a watcher and access its notification channels.
+	watcher, err := fswatcher.New(certFile.Name(), keyFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, errChan := watcher.Watch()
+
+	// Ensure an error is propagated from parsing the empty cert.
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("expected a certificate error")
+	case certErr, ok := <-errChan:
+		if !ok || !strings.Contains(certErr.Error(), "failed to find any PEM data") {
+			t.Error(certErr)
+		}
+	}
+
+	// Close the watch and ensure all goroutines have exited.
+	err = watcher.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; runtime.NumGoroutine() != goCount && i < 10; i++ {
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if n := runtime.NumGoroutine(); n != goCount {
+		t.Fatalf("expected %v goroutines, found %v", goCount, n)
+	}
+
+	// Ensure that the error channel has been closed.
+	select {
+	default:
+		t.Errorf("default case on select of channel expected to be closed")
+	case _, ok := <-errChan:
+		if ok {
+			t.Errorf("receive on channel expected to be closed")
+		}
+	}
+}


### PR DESCRIPTION
Detect closure of channels using tuple assignment in select expressions.

Exit goroutine for-loops and close write channels in defer statements.