### PR TITLE
fix(certinel): do not return nil client cert

### DIFF
--- a/certinel.go
+++ b/certinel.go
@@ -99,5 +99,9 @@ func (c *Certinel) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certif
 // safe to call across multiple goroutines.
 func (c *Certinel) GetClientCertificate(certificateRequest *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 	cert, _ := c.certificate.Load().(*tls.Certificate)
-	return cert, nil
+	if cert == nil {
+		return &tls.Certificate{}, nil
+	} else {
+		return cert, nil
+	}
 }


### PR DESCRIPTION
The documentation and requirements for the methods `GetCertificate` and
`GetClientCertificate` are slightly different. The latter must not return
`nil` and should instead return an empty `tls.Certificate`, or else
trigger a nil-dereference in `crypto/tls` during the client handshake.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x65df22]

    goroutine 39 [running]:
    crypto/tls.(*clientHandshakeStateTLS13).sendClientCertificate(0xc0001ebe20, 0x0, 0x0)
	    /usr/local/go/src/crypto/tls/handshake_client_tls13.go:537 +0x122
    crypto/tls.(*clientHandshakeStateTLS13).handshake(0xc0001ebe20, 0xc000200100, 0x0)
	    /usr/local/go/src/crypto/tls/handshake_client_tls13.go:91 +0x230
    crypto/tls.(*Conn).clientHandshake(0xc00020a000, 0x0, 0x0)
	    /usr/local/go/src/crypto/tls/handshake_client.go:196 +0x4d9
    crypto/tls.(*Conn).Handshake(0xc00020a000, 0x0, 0x0)
	    /usr/local/go/src/crypto/tls/conn.go:1340 +0xcc
    net/http.(*persistConn).addTLS.func2(0x0, 0xc00020a000, 0x0, 0xc000186480)
	    /usr/local/go/src/net/http/transport.go:1453 +0x42
    created by net/http.(*persistConn).addTLS
	    /usr/local/go/src/net/http/transport.go:1449 +0x1aa
    FAIL    github.com/cloudflare/certinel  0.018s
    ok      github.com/cloudflare/certinel/fswatcher        (cached)
    FAIL