### PR TITLE
Have Watch block until the initial load of the key pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ func main() {
 	sentinel := certinel.New(watcher, func(err error) {
 		log.Printf("error: certinel was unable to reload the certificate. err='%s'", err)
 	})
-
-	sentinel.Watch()
+	if err := sentinel.Watch(); err != nil {
+		log.Fatalf("fatal: unable to read server certificate. err='%s'", err)
+	}
 
 	server := http.Server{
 		Addr: ":8000",

--- a/fswatcher/fswatcher.go
+++ b/fswatcher/fswatcher.go
@@ -22,7 +22,6 @@ type Sentry struct {
 }
 
 const (
-	errAddWatcher      = "fswatcher: error adding path to watcher"
 	errCreateWatcher   = "fswatcher: error creating watcher"
 	errLoadCertificate = "fswatcher: error loading certificate"
 )
@@ -32,10 +31,6 @@ func New(cert, key string) (*Sentry, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, errors.Wrap(err, errCreateWatcher)
-	}
-
-	if err != nil {
-		return nil, errors.Wrap(err, errAddWatcher)
 	}
 
 	fsw := &Sentry{


### PR DESCRIPTION
This allows clients to fail fast in case of error, and otherwise know
subsequent calls to GetCertificate/GetClientCertificate will succeed.