### PR TITLE
Add Wait method which blocks on initial load of certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ func main() {
 
 	sentinel.Watch()
 
+	// Optional: block until the initial certificate load completes.
+	if err := sentinel.Wait(context.Background()); err != nil {
+		log.Fatalf("fatal: unable to read server certificate. err='%s'", err)
+	}
+
 	server := http.Server{
 		Addr: ":8000",
 		TLSConfig: &tls.Config{


### PR DESCRIPTION
This allows clients to fail fast in case of error, and otherwise know
subsequent calls to GetCertificate/GetClientCertificate will succeed.