### PR TITLE
chore: document the atomic writer pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,23 @@ func main() {
 	}
 }
 ```
+
+### Use Atomic Update Pattern
+
+If using a filesystem-based certinel with in an environment where both
+the keys and certificates are updated, care should be taken to update
+both atomically. This is automatically done in some environments, such
+as mounting a secret as a volume in Kubernetes.
+
+1. Create the initial key and certificate in a hidden directory.
+   (`./ssl/.first/app.pem` and `./ssl/.first/app.key`)
+2. Create hidden symlink to this directory (`./ssl/..data` ->
+   `./ssl/.first`)
+3. Create visible files through the hidden symlink (`./ssl/app.pem` ->
+   `./ssl/..data/app.pem`)
+4. When updating the key and certificate, write them into a new hidden
+   directory (`./ssl/.second/app.pem` and `./ssl/.second/app.key`)
+5. Create a new hidden symlink to this new directory (`./ssl/..data_new`
+   -> `./ssl/.second`)
+6. Finally, move this new hidden symlink over the old one (`mv
+   ./ssl/..data_new ./ssl/..data`)

--- a/fswatcher/fswatcher_atomic_test.go
+++ b/fswatcher/fswatcher_atomic_test.go
@@ -1,0 +1,91 @@
+// +build !windows
+
+package fswatcher
+
+import (
+	"context"
+	"crypto/x509"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/certinel/internel/pkitest"
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sync/errgroup"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/poll"
+)
+
+const (
+	atomicDirName    = "..data"
+	atomicNewDirName = "..data_tmp"
+)
+
+func TestWatcher_AtomicWriter(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pk1 := pkitest.NewPrivateKey(t)
+	pemPK1 := pkitest.EncodePrivateKey(t, pk1)
+
+	pk2 := pkitest.NewPrivateKey(t)
+	pemPK2 := pkitest.EncodePrivateKey(t, pk2)
+
+	dir := fs.NewDir(t, "test-symlink",
+		fs.WithDir(".first",
+			fs.WithFile("my.crt", "", fs.WithBytes(
+				pkitest.PemEncodeCertificate(t, x509.Certificate{
+					SerialNumber: big.NewInt(1),
+				}, pk1),
+			)),
+			fs.WithFile("my.key", "", fs.WithBytes(pemPK1)),
+		),
+		fs.WithDir(".second",
+			fs.WithFile("my.crt", "", fs.WithBytes(
+				pkitest.PemEncodeCertificate(t, x509.Certificate{
+					SerialNumber: big.NewInt(2),
+				}, pk2),
+			)),
+			fs.WithFile("my.key", "", fs.WithBytes(pemPK2)),
+		),
+		fs.WithSymlink(atomicDirName, ".first"),
+		fs.WithSymlink("my.key", filepath.Join(atomicDirName, "my.key")),
+		fs.WithSymlink("my.crt", filepath.Join(atomicDirName, "my.crt")),
+	)
+	defer dir.Remove()
+
+	watcher, err := New(dir.Join("my.crt"), dir.Join("my.key"))
+	assert.NilError(t, err)
+
+	cert, err := watcher.GetCertificate(nil)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, cert.Leaf.SerialNumber, big.NewInt(1), cmp.Comparer(pkitest.CmpBigInt))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return watcher.Start(gctx)
+	})
+	<-time.After(100 * time.Millisecond)
+
+	fs.Apply(t, dir, fs.WithSymlink(atomicNewDirName, ".second"))
+
+	err = os.Rename(dir.Join(atomicNewDirName), dir.Join(atomicDirName))
+	assert.NilError(t, err)
+
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		cert, err := watcher.GetCertificate(nil)
+		if err != nil {
+			return poll.Error(err)
+		}
+
+		return poll.Compare(is.DeepEqual(cert.Leaf.SerialNumber, big.NewInt(2), cmp.Comparer(pkitest.CmpBigInt)))
+	})
+
+	cancel()
+	assert.ErrorType(t, g.Wait(), context.Canceled)
+}


### PR DESCRIPTION
When certinels reload certificates from disk, either via timer or being
notified by the filesystem, they reload both the certificates and the
keys from disk. If the certificate and keys do not match, the certinels
exit with an error. This can cause problems if the keys and certificates
are not updated together atomically, as the watcher may trigger after
only one has been updated.

This changeset adds a test for Kubernetes's atomic writer[1] pattern,
and documents a similar pattern that users who update key and
certificates can follow.

[1]: https://github.com/kubernetes/kubernetes/blob/v1.21.3/pkg/volume/util/atomic_writer.go#L49-L54

Fixes #14