### PR TITLE
feat: use atomic.Pointer[T]

### DIFF
--- a/fswatcher/fswatcher.go
+++ b/fswatcher/fswatcher.go
@@ -20,7 +20,7 @@ import (
 // Sentinel watches for filesystem change events that effect the watched certificate.
 type Sentinel struct {
 	certPath, keyPath string
-	certificate       atomic.Value
+	certificate       atomic.Pointer[tls.Certificate]
 }
 
 const fsCreateOrWriteOpMask = fsnotify.Create | fsnotify.Write
@@ -97,12 +97,11 @@ func (w *Sentinel) loadCertificate() error {
 }
 
 func (w *Sentinel) GetCertificate(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	cert, _ := w.certificate.Load().(*tls.Certificate)
-	return cert, nil
+	return w.certificate.Load(), nil
 }
 
 func (w *Sentinel) GetClientCertificate(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	cert, _ := w.certificate.Load().(*tls.Certificate)
+	cert := w.certificate.Load()
 	if cert == nil {
 		cert = &tls.Certificate{}
 	}

--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -23,7 +23,7 @@ type Sentinel struct {
 	certPath, keyPath string
 	duration          time.Duration
 	ticker            func(d time.Duration) ticker
-	certificate       atomic.Value
+	certificate       atomic.Pointer[tls.Certificate]
 }
 
 func New(cert, key string, duration time.Duration) (*Sentinel, error) {
@@ -75,12 +75,11 @@ func (w *Sentinel) Start(ctx context.Context) error {
 }
 
 func (w *Sentinel) GetCertificate(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	cert, _ := w.certificate.Load().(*tls.Certificate)
-	return cert, nil
+	return w.certificate.Load(), nil
 }
 
 func (w *Sentinel) GetClientCertificate(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	cert, _ := w.certificate.Load().(*tls.Certificate)
+	cert := w.certificate.Load()
 	if cert == nil {
 		cert = &tls.Certificate{}
 	}


### PR DESCRIPTION
Replace usage of atomic.Value with atomic.Pointer[tls.Cpertificate] in implementations of certinel where pointers were already being stored. The generic implementation of atomic was introduced in Go 1.19, which is well outside the supported range.